### PR TITLE
Enabling snapping and randomizing vector origin on creation

### DIFF
--- a/common/pixi/view/arrow-draggable.js
+++ b/common/pixi/view/arrow-draggable.js
@@ -12,7 +12,7 @@ define(function(require) {
 
     // Default snapping function just snaps to nearest 10 pixels
     var defaultSnappingFunction = function(coordinateComponent) {
-        return Math.round(coordinateComponent / 10) * 10;
+        return Math.round(coordinateComponent / 15) * 15;
     };
 
 
@@ -100,7 +100,7 @@ define(function(require) {
                 var local = data.getLocalPosition(this.displayObject.parent, this._dragLocation);
                 var dx = local.x - this.displayObject.x - this.dragOffset.x;
                 var dy = local.y - this.displayObject.y - this.dragOffset.y;
-                
+
                 if (this.snappingEnabled) {
                     this._attributes.originX = this.snappingXFunction(this.model.get('originX') + dx);
                     this._attributes.originY = this.snappingYFunction(this.model.get('originY') + dy);
@@ -144,7 +144,7 @@ define(function(require) {
                 var local = data.getLocalPosition(this.displayObject, this._dragLocation);
                 var x = this.model.get('originX') + local.x - this.dragOffset.x;
                 var y = this.model.get('originY') + local.y - this.dragOffset.y;
-                
+
                 delete this._attributes.originX;
                 delete this._attributes.originY;
                 if (this.snappingEnabled) {
@@ -160,7 +160,7 @@ define(function(require) {
                 var origin = this._originVector.set(this.model.get('originX'), this.model.get('originY'));
                 var target = this._targetVector.set(this._attributes.targetX, this._attributes.targetY);
                 var length = origin.distance(target);
-                
+
                 if ((this.model.get('minLength') === null || this.model.get('minLength') === undefined || length >= this.model.get('minLength')) &&
                     (this.model.get('maxLength') === null || this.model.get('maxLength') === undefined || length <= this.model.get('maxLength'))
                 ) {

--- a/common/pixi/view/arrow-draggable.js
+++ b/common/pixi/view/arrow-draggable.js
@@ -10,7 +10,7 @@ define(function(require) {
     var Colors  = require('../../colors/colors');
     var Vector2 = require('../../math/vector2');
 
-    // Default snapping function just snaps to nearest 10 pixels
+    // Default snapping function just snaps to nearest 15 pixels
     var defaultSnappingFunction = function(coordinateComponent) {
         return Math.round(coordinateComponent / 15) * 15;
     };

--- a/common/pixi/view/arrow-draggable.js
+++ b/common/pixi/view/arrow-draggable.js
@@ -10,9 +10,9 @@ define(function(require) {
     var Colors  = require('../../colors/colors');
     var Vector2 = require('../../math/vector2');
 
-    // Default snapping function just snaps to nearest 15 pixels
+    // Default snapping function just snaps to nearest 10 pixels
     var defaultSnappingFunction = function(coordinateComponent) {
-        return Math.round(coordinateComponent / 15) * 15;
+        return Math.round(coordinateComponent / 10) * 10;
     };
 
 

--- a/vector-addition/src/js/models/vectors.js
+++ b/vector-addition/src/js/models/vectors.js
@@ -3,17 +3,25 @@ define(function(require) {
   'use strict'
 
   var DraggableArrowView = require('common/pixi/view/arrow-draggable');
+  var Constants = require('constants');
+
 
   var ArrowViewModel = DraggableArrowView.ArrowViewModel.extend({
+
     defaults: {
-      originX: 300,
-      originY: 300,
-      targetX: 380,
-      targetY: 220
+
     },
 
     initialize: function(attributes, options) {
+      var originX = 0.8 * Constants.CANVAS_WIDTH + 15 * Math.random() - 10;
+      var originY = 0.25 * Constants.CANVAS_HEIGHT + 15 * Math.random() - 10;
+      var targetX = originX + 80;
+      var targetY = originY - 80;
 
+      this.set('originX', originX);
+      this.set('originY', originY);
+      this.set('targetX', targetX);
+      this.set('targetY', targetY);
     }
 
   });

--- a/vector-addition/src/js/views/vectors.js
+++ b/vector-addition/src/js/views/vectors.js
@@ -54,7 +54,8 @@ define(function(require) {
 
     drawVector: function() {
       this.arrowView = new DraggableArrowView({
-          model: this.vectorViewModel
+          model: this.vectorViewModel,
+          snappingEnabled: true
       });
 
       this.tailGraphics = this.arrowView.tailGraphics;

--- a/vector-addition/src/js/views/vectors.js
+++ b/vector-addition/src/js/views/vectors.js
@@ -55,7 +55,9 @@ define(function(require) {
     drawVector: function() {
       this.arrowView = new DraggableArrowView({
           model: this.vectorViewModel,
-          snappingEnabled: true
+          snappingEnabled: true,
+          snappingXFunction: this.defaultSnappingFunction,
+          snappingYFunction: this.defaultSnappingFunction
       });
 
       this.tailGraphics = this.arrowView.tailGraphics;
@@ -143,6 +145,10 @@ define(function(require) {
 
         this.model.set('deleteVector', false);
       }
+    },
+
+    defaultSnappingFunction: function(coordinateComponent) {
+      return Math.round(coordinateComponent / 15) * 15;
     }
 
   });


### PR DESCRIPTION
Fixes part of https://github.com/Connexions/simulations/issues/108, although the arrow is still not draggable out of bucket. 

Also fixes https://github.com/Connexions/simulations/issues/129