### PR TITLE
Fixed a bug in common/pixi/extensions' Texture.generateCircleTexture

### DIFF
--- a/common/pixi/extensions.js
+++ b/common/pixi/extensions.js
@@ -329,8 +329,8 @@ define(function(require) {
 
         // Draw on a canvas and then use it as a texture for our particles
         var canvas = document.createElement('canvas');
-        canvas.width  = radius * 2 + outlineWidth;
-        canvas.height = radius * 2 + outlineWidth;
+        canvas.width  = radius * 2 + outlineWidth * 2;
+        canvas.height = radius * 2 + outlineWidth * 2;
 
         var ctx = canvas.getContext('2d');
 


### PR DESCRIPTION
Realized when rendering the oxygen atoms that the canvas width/height was a pixel off, and this was because I was only adding the outline width once instead of twice (to account for both sides of the shape).