### PR TITLE
Fixing temperature reset on a molecule-type change

### DIFF
--- a/states-of-matter/src/js/models/simulation.js
+++ b/states-of-matter/src/js/models/simulation.js
@@ -661,13 +661,13 @@ define(function (require, exports, module) {
                 return;
             }
 
-            // Remove existing particles and reset the global model parameters.
-            this.removeAllParticles();
-            this.initModelParameters();
-
             // Retain the current phase so that we can set the particles back to
             //   this phase once they have been created and initialized.
             var phase = this.mapTemperatureToPhase();
+
+            // Remove existing particles and reset the global model parameters.
+            this.removeAllParticles();
+            this.initModelParameters();
 
             // Set the new molecule type.
             this.currentMolecule = moleculeType;


### PR DESCRIPTION
Somehow I got into thinking that having the temperature reset was the original behavior, and I remember purposely switching the order here, but now I see that it's supposed to retain the temperature through molecule-type changes, so I've fixed it.

Fixes #195