### PR TITLE
Fixing switched phase diagrams

### DIFF
--- a/states-of-matter/src/js/views/phase-diagram.js
+++ b/states-of-matter/src/js/views/phase-diagram.js
@@ -106,14 +106,14 @@ define(function(require) {
             var topOfSolidLiquidLine;
             if (this.depictingWater) {
                 topOfSolidLiquidLine = new Vector2(
-                    C.DEFAULT_TOP_OF_SOLID_LIQUID_LINE.x * gw,
-                    C.DEFAULT_TOP_OF_SOLID_LIQUID_LINE.y * -gh
+                    C.TOP_OF_SOLID_LIQUID_LINE_FOR_WATER.x * gw,
+                    C.TOP_OF_SOLID_LIQUID_LINE_FOR_WATER.y * -gh
                 );
             }
             else {
                 topOfSolidLiquidLine = new Vector2(
-                    C.TOP_OF_SOLID_LIQUID_LINE_FOR_WATER.x * gw,
-                    C.TOP_OF_SOLID_LIQUID_LINE_FOR_WATER.y * -gh
+                    C.DEFAULT_TOP_OF_SOLID_LIQUID_LINE.x * gw,
+                    C.DEFAULT_TOP_OF_SOLID_LIQUID_LINE.y * -gh
                 );
             }
 


### PR DESCRIPTION
I had made it exactly the opposite of what it should have been.  The water diagram is different from all the others, and I gave the one that went to the water to all the others and vice versa.
Fixes #196