### PR TITLE
Changing footer image references to point to internal common directories

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,10 +19,6 @@ module.exports = function(grunt){
 			dist: {
 				src: '*/dist/**/*',
 				dest: 'dist/'
-			},
-			common: {
-				src: 'common/img/*',
-				dest: 'dist/'
 			}
 		},
 		targethtml: {
@@ -137,7 +133,6 @@ module.exports = function(grunt){
 	grunt.registerTask('copy-dists', [
 		'clean:dist',
 		'copy:dist',
-        'copy:common',
 		'fix-dist-directories'
 	]);
 

--- a/arrow-test/Gruntfile.js
+++ b/arrow-test/Gruntfile.js
@@ -37,7 +37,9 @@ module.exports = function(grunt) {
 			},
 			common: {
 				src: [
-					'../common/**/*.{eot,svg,ttf,woff,otf}'
+					'!../common/**/docs/**/*',
+                    '../common/**/*.{eot,svg,ttf,woff,otf}',
+                    '../common/img/**/*.{png,jpg,jpeg,gif}'
 				],
 				dest: 'dist/common/'
 			}

--- a/common/app/app.html
+++ b/common/app/app.html
@@ -16,8 +16,8 @@
 </div>
 
 <div class="footer">
-  <div class="col-md-4"><div class="logo"><a href="http://cnx.org/" target="_blank"><img src="../common/img/cnx_logo_white.png"></a></div></div>
+  <div class="col-md-4"><div class="logo"><a href="http://cnx.org/" target="_blank"><img src="common/img/cnx_logo_white.png"></a></div></div>
   <div class="col-md-4"></div>
   <div class="col-md-4"><div class="logo"><div class="pull-right"><span class="middle">Derived from</span>
-    <a href="https://phet.colorado.edu/en/simulation/<%= link %>" target="_blank"><img src="../common/img/PhET_logo_notagline.png"></a></div></div></div>
+    <a href="https://phet.colorado.edu/en/simulation/<%= link %>" target="_blank"><img src="common/img/PhET_logo_notagline.png"></a></div></div></div>
 </div>

--- a/energy-forms-and-changes/Gruntfile.js
+++ b/energy-forms-and-changes/Gruntfile.js
@@ -34,7 +34,9 @@ module.exports = function(grunt){
             },
             common: {
                 src: [
-                    '../common/**/*.{eot,svg,ttf,woff,otf}'
+                    '!../common/**/docs/**/*',
+                    '../common/**/*.{eot,svg,ttf,woff,otf}',
+                    '../common/img/**/*.{png,jpg,jpeg,gif}'
                 ],
                 dest: 'dist/common/'
             }

--- a/gravity-and-orbits/Gruntfile.js
+++ b/gravity-and-orbits/Gruntfile.js
@@ -34,7 +34,9 @@ module.exports = function(grunt){
 			},
 			common: {
 				src: [
-					'../common/**/*.{eot,svg,ttf,woff,otf}'
+					'!../common/**/docs/**/*',
+                    '../common/**/*.{eot,svg,ttf,woff,otf}',
+                    '../common/img/**/*.{png,jpg,jpeg,gif}'
 				],
 				dest: 'dist/common/'
 			}

--- a/masses-and-springs/Gruntfile.js
+++ b/masses-and-springs/Gruntfile.js
@@ -37,7 +37,9 @@ module.exports = function(grunt) {
 			},
 			common: {
 				src: [
-					'../common/**/*.{eot,svg,ttf,woff,otf}'
+					'!../common/**/docs/**/*',
+                    '../common/**/*.{eot,svg,ttf,woff,otf}',
+                    '../common/img/**/*.{png,jpg,jpeg,gif}'
 				],
 				dest: 'dist/common/'
 			}

--- a/moving-man/Gruntfile.js
+++ b/moving-man/Gruntfile.js
@@ -34,7 +34,9 @@ module.exports = function(grunt){
 			},
 			common: {
 				src: [
-					'../common/**/*.{eot,svg,ttf,woff,otf}'
+					'!../common/**/docs/**/*',
+                    '../common/**/*.{eot,svg,ttf,woff,otf}',
+                    '../common/img/**/*.{png,jpg,jpeg,gif}'
 				],
 				dest: 'dist/common/'
 			}

--- a/my-solar-system/Gruntfile.js
+++ b/my-solar-system/Gruntfile.js
@@ -37,7 +37,9 @@ module.exports = function(grunt) {
 			},
 			common: {
 				src: [
-					'../common/**/*.{eot,svg,ttf,woff,otf}'
+					'!../common/**/docs/**/*',
+                    '../common/**/*.{eot,svg,ttf,woff,otf}',
+                    '../common/img/**/*.{png,jpg,jpeg,gif}'
 				],
 				dest: 'dist/common/'
 			}

--- a/projectile-motion/Gruntfile.js
+++ b/projectile-motion/Gruntfile.js
@@ -39,7 +39,9 @@ module.exports = function(grunt) {
 			},
 			common: {
 				src: [
-					'../common/**/*.{eot,svg,ttf,woff,otf}'
+					'!../common/**/docs/**/*',
+                    '../common/**/*.{eot,svg,ttf,woff,otf}',
+                    '../common/img/**/*.{png,jpg,jpeg,gif}'
 				],
 				dest: 'dist/common/'
 			}

--- a/states-of-matter/Gruntfile.js
+++ b/states-of-matter/Gruntfile.js
@@ -37,7 +37,9 @@ module.exports = function(grunt) {
 			},
 			common: {
 				src: [
-					'../common/**/*.{eot,svg,ttf,woff,otf}'
+					'!../common/**/docs/**/*',
+                    '../common/**/*.{eot,svg,ttf,woff,otf}',
+                    '../common/img/**/*.{png,jpg,jpeg,gif}'
 				],
 				dest: 'dist/common/'
 			}

--- a/template/Gruntfile.js
+++ b/template/Gruntfile.js
@@ -37,7 +37,9 @@ module.exports = function(grunt) {
 			},
 			common: {
 				src: [
-					'../common/**/*.{eot,svg,ttf,woff,otf}'
+					'!../common/**/docs/**/*',
+                    '../common/**/*.{eot,svg,ttf,woff,otf}',
+                    '../common/img/**/*.{png,jpg,jpeg,gif}'
 				],
 				dest: 'dist/common/'
 			}

--- a/vector-addition/Gruntfile.js
+++ b/vector-addition/Gruntfile.js
@@ -34,7 +34,9 @@ module.exports = function(grunt){
 			},
 			common: {
 				src: [
-					'../common/**/*.{eot,svg,ttf,woff,otf}'
+					'!../common/**/docs/**/*',
+                    '../common/**/*.{eot,svg,ttf,woff,otf}',
+                    '../common/img/**/*.{png,jpg,jpeg,gif}'
 				],
 				dest: 'dist/common/'
 			}

--- a/wave-interference/Gruntfile.js
+++ b/wave-interference/Gruntfile.js
@@ -28,7 +28,9 @@ module.exports = function(grunt){
 			},
 			common: {
 				src: [
-					'../common/**/*.{eot,svg,ttf,woff,otf}'
+					'!../common/**/docs/**/*',
+                    '../common/**/*.{eot,svg,ttf,woff,otf}',
+                    '../common/img/**/*.{png,jpg,jpeg,gif}'
 				],
 				dest: 'dist/common/'
 			}


### PR DESCRIPTION
All the dist copy scripts now look for the footer images and make sure they're included in the dist folder, and the footer image references point to that internal common directory instead of the shared one.

Resolves #160.