### PR TITLE
fixing body drop ignoring gravity change bug

### DIFF
--- a/masses-and-springs/src/js/models/simulation.js
+++ b/masses-and-springs/src/js/models/simulation.js
@@ -84,7 +84,7 @@ define(function (require, exports, module) {
                 system.set('gravity', gravity);
             });
             this.bodies.each(function(body){
-                body.set('gravity', gravity);
+                body.set('acceleration', gravity);
             });
         },
 


### PR DESCRIPTION
Body drop was not acting according to gravity.  This was due to a property renaming.  The bug was most apparent when the gravity was set to 0 and the body still dropped according to earth's gravity.