### PR TITLE
Before the explosion overlay would fade in again after switching tabs…

### DIFF
--- a/nuclear-fission/src/js/views/sim/chain-reaction.js
+++ b/nuclear-fission/src/js/views/sim/chain-reaction.js
@@ -315,7 +315,10 @@ define(function (require) {
                     backgroundPosition: xOffset + 'px ' + yOffset + 'px'
                 });
 
-                this.$explosionOverlay.appendTo(this.$el);
+                this.$explosionOverlay
+                    .hide()
+                    .appendTo(this.$el)
+                    .fadeIn(3000);
                 this.$el.addClass('exploded');
             }
             else {

--- a/nuclear-fission/src/styles/sim.less
+++ b/nuclear-fission/src/styles/sim.less
@@ -146,9 +146,6 @@
     top: 0;
     left: 0;
     z-index: 9999;
-    .animation-name(overlay-animation);
-    .animation-duration(@explosion-animation-duration);
-    .animation-fill-mode(forwards);
 
     @media screen and (max-height: @short-window) {
         height: @short-scene-height;
@@ -164,27 +161,6 @@
         font-family: monospace;
     }
 }
-
-@-webkit-keyframes overlay-animation {
-      0% { opacity: 0; }
-    100% { opacity: 1; }
-}
-
-@-moz-keyframes overlay-animation {
-      0% { opacity: 0; }
-    100% { opacity: 1; }
-}
-
-@-o-keyframes overlay-animation {
-      0% { opacity: 0; }
-    100% { opacity: 1; }
-}
-
-@keyframes overlay-animation {
-      0% { opacity: 0; }
-    100% { opacity: 1; }
-}
-
 
 @graph-width: 40px;
 @graph-height: 150px;


### PR DESCRIPTION
… and switching back because it was a CSS animation that animated upon the element becoming visible.  The simplest solution was to just make it a jQuery animation, and it's simple enough that it shouldn't be much of a performance issue.