### PR TITLE
Hydrogen Atom: Fixes the disappearing-electron problem

### DIFF
--- a/hydrogen-atom/src/js/views/energy-diagram.js
+++ b/hydrogen-atom/src/js/views/energy-diagram.js
@@ -85,7 +85,10 @@ define(function(require) {
             var mvt = ModelViewTransform.createScaleMapping(22);
             var electronDisplayObject = ParticleGraphicsGenerator.generateElectron(mvt);
             var canvas = PixiToImage.displayObjectToCanvas(electronDisplayObject, 1);
-            this.electronImage = canvas;
+            var self = this;
+            createImageBitmap(canvas).then(function(imageBitmap) {
+                self.electronImageBitmap = imageBitmap;
+            });
         },
 
         setWidth: function(width) {
@@ -272,7 +275,8 @@ define(function(require) {
         },
 
         drawElectron: function(ctx, x, y) {
-            ctx.drawImage(this.electronImage, x - this.electronImage.width / 2, y - this.electronImage.height / 2);
+            if (this.electronImageBitmap)
+                ctx.drawImage(this.electronImageBitmap, x - this.electronImageBitmap.width / 2, y - this.electronImageBitmap.height / 2);
         },
 
         drawStateLine: function(ctx, x, y) {

--- a/hydrogen-atom/src/js/views/energy-diagram/bohr.js
+++ b/hydrogen-atom/src/js/views/energy-diagram/bohr.js
@@ -104,7 +104,7 @@ define(function(require) {
 
             // Place the electron
             var x = this.getXOffset(n) + (this.stateLineLength / 2);
-            var y = this.getYOffset(n) - this.electronImage.height / 2;
+            var y = this.getYOffset(n) - this.electronImageBitmap.height / 2;
             this.drawElectron(ctx, x, y);
         },
 

--- a/hydrogen-atom/src/js/views/energy-diagram/schroedinger.js
+++ b/hydrogen-atom/src/js/views/energy-diagram/schroedinger.js
@@ -142,7 +142,7 @@ define(function(require) {
 
             // Place the electron
             var x = this.getXOffset(l) + (this.stateLineLength / 2);
-            var y = this.getYOffset(n) - this.electronImage.height / 2;
+            var y = this.getYOffset(n) - this.electronImageBitmap.height / 2;
             this.drawElectron(ctx, x, y);
         },
 


### PR DESCRIPTION
Previously the electron would sometimes disappear from the energy diagram view when switching tabs or blurring the window or going away somehow and coming back.  I think that perhaps the browser was forgetting what was drawn on the canvas that represented the electron, so I baked it into an ImageBitmap that should just exist in normal memory and not get lost.